### PR TITLE
Modernize Python 2 code to get ready for Python 3

### DIFF
--- a/src/datasets/fusion.py
+++ b/src/datasets/fusion.py
@@ -1,10 +1,12 @@
+from __future__ import print_function
+from __future__ import absolute_import
 import torch.utils.data as data
 import numpy as np
 import ref
 import torch
 import cv2
-from mpii import MPII
-from h36m import H36M
+from .mpii import MPII
+from .h36m import H36M
 
 class Fusion(data.Dataset):
   def __init__(self, opt, split):
@@ -15,7 +17,7 @@ class Fusion(data.Dataset):
     self.nImages2D = len(self.dataset2D)
     self.nImages3D = min(len(self.dataset3D), int(self.nImages2D * self.ratio3D))
     
-    print '#Images2D {}, #Images3D {}'.format(self.nImages2D, self.nImages3D)
+    print('#Images2D {}, #Images3D {}'.format(self.nImages2D, self.nImages3D))
   def __getitem__(self, index):
     if index < self.nImages3D:
       return self.dataset3D[index]

--- a/src/datasets/h36m.py
+++ b/src/datasets/h36m.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import torch.utils.data as data
 import numpy as np
 import ref
@@ -9,7 +10,7 @@ from utils.img import Crop, DrawGaussian, Transform3D
 
 class H36M(data.Dataset):
   def __init__(self, opt, split):
-    print '==> initializing 3D {} data.'.format(split)
+    print('==> initializing 3D {} data.'.format(split))
     annot = {}
     tags = ['action', 'bbox', 'camera', 'id', 'joint_2d', 'joint_3d_mono', 'subaction', 'subject', 'istrain']
     f = File('../data/h36m/annotSampleTest.h5', 'r')
@@ -27,7 +28,7 @@ class H36M(data.Dataset):
     self.annot = annot
     self.nSamples = len(self.annot['id'])
     
-    print 'Loaded 3D {} {} samples'.format(split, len(self.annot['id']))
+    print('Loaded 3D {} {} samples'.format(split, len(self.annot['id'])))
   
   def LoadImage(self, index):
     folder = 's_{:02d}_act_{:02d}_subact_{:02d}_ca_{:02d}'.format(self.annot['subject'][index], self.annot['action'][index], \

--- a/src/datasets/mpii.py
+++ b/src/datasets/mpii.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import torch.utils.data as data
 import numpy as np
 import ref
@@ -9,7 +10,7 @@ from utils.img import Crop, DrawGaussian, Transform
 
 class MPII(data.Dataset):
   def __init__(self, opt, split, returnMeta = False):
-    print '==> initializing 2D {} data.'.format(split)
+    print('==> initializing 2D {} data.'.format(split))
     annot = {}
     tags = ['imgname','part','center','scale']
     f = File('{}/mpii/annot/{}.h5'.format(ref.dataDir, split), 'r')
@@ -17,7 +18,7 @@ class MPII(data.Dataset):
       annot[tag] = np.asarray(f[tag]).copy()
     f.close()
 
-    print 'Loaded 2D {} {} samples'.format(split, len(annot['scale']))
+    print('Loaded 2D {} {} samples'.format(split, len(annot['scale'])))
     
     self.split = split
     self.opt = opt

--- a/src/tools/GetH36M.py
+++ b/src/tools/GetH36M.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import scipy.io as sio
 import numpy as np
 import h5py
@@ -33,12 +34,12 @@ for split in range(2):
       for subaction in subaction_list:
         for camera in camera_list:
           folder_name = 's_{:02d}_act_{:02d}_subact_{:02d}_ca_{:02d}'.format(subject, action, subaction, camera)
-          print folder_name
+          print(folder_name)
           annot_file = IMG_PATH + folder_name + '/' + annot_name
           try:
             data = sio.loadmat(annot_file)
           except:
-            print 'pass', folder_name
+            print('pass', folder_name)
             continue
           n = data['num_images'][0][0]
           meta_Y2d = data['Y2d'].reshape(17, 2, n)
@@ -60,7 +61,7 @@ for split in range(2):
             istrain.append(1 - split)
             num += 1
           
-print 'num = ', num
+print('num = ', num)
 h5name = SAVE_PATH + 'annotSampleTest.h5'
 f = h5py.File(h5name, 'w')
 f['id'] = id

--- a/src/train.py
+++ b/src/train.py
@@ -51,7 +51,7 @@ def step(split, epoch, opt, dataLoader, model, criterion, optimizer = None):
       optimizer.step()
  
     Bar.suffix = '{split} Epoch: [{0}][{1}/{2}]| Total: {total:} | ETA: {eta:} | Loss {loss.avg:.6f} | Loss3D {loss3d.avg:.6f} | Acc {Acc.avg:.6f} | Mpjpe {Mpjpe.avg:.6f} ({Mpjpe.val:.6f})'.format(epoch, i, nIters, total=bar.elapsed_td, eta=bar.eta_td, loss=Loss, Acc=Acc, split = split, Mpjpe=Mpjpe, loss3d = Loss3D)
-    bar.next()
+    next(bar)
 
   bar.finish()
   return Loss.avg, Acc.avg, Mpjpe.avg, Loss3D.avg


### PR DESCRIPTION
Make the minimal, safe changes required to convert the repo's code to be syntax compatible with both Python 2 and Python 3.  There might be other changes required to complete a port to Python 3 but this PR is a minimal, safe first step.

Run: [futurize --stage1 -w **/*.py](http://python-future.org/futurize_cheatsheet.html)

    See Stage 1: "safe" fixes http://python-future.org/automatic_conversion.html#stage-1-safe-fixes
